### PR TITLE
Add log buffer behaviour

### DIFF
--- a/console-sample/src/main/java/com/jraska/console/sample/ConsoleActivity.java
+++ b/console-sample/src/main/java/com/jraska/console/sample/ConsoleActivity.java
@@ -5,14 +5,16 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
+
 import com.jraska.console.Console;
-import timber.log.Timber;
 
 import java.text.DateFormat;
 import java.util.Date;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import timber.log.Timber;
 
 public class ConsoleActivity extends AppCompatActivity {
 
@@ -84,6 +86,11 @@ public class ConsoleActivity extends AppCompatActivity {
       return true;
     }
 
+    if(id == R.id.action_console_mass_text) {
+      onMassTextClicked();
+      return true;
+    }
+
     return super.onOptionsItemSelected(item);
   }
 
@@ -103,6 +110,12 @@ public class ConsoleActivity extends AppCompatActivity {
   void onAsyncClicked() {
     ChattyAsync chattyAsync = new ChattyAsync();
     chattyAsync.execute(1000L);
+  }
+
+  void onMassTextClicked() {
+    Console.shouldBufferLogs(true);
+    MassTextAsync async = new MassTextAsync();
+    async.execute(100 * 1000L); // should take a while to print 100,000 lines.
   }
 
   //endregion

--- a/console-sample/src/main/java/com/jraska/console/sample/ConsoleApp.java
+++ b/console-sample/src/main/java/com/jraska/console/sample/ConsoleApp.java
@@ -2,8 +2,9 @@ package com.jraska.console.sample;
 
 import android.app.Application;
 import android.util.Log;
-import com.jraska.console.Console;
+
 import com.jraska.console.timber.ConsoleTree;
+
 import timber.log.Timber;
 
 public class ConsoleApp extends Application {

--- a/console-sample/src/main/java/com/jraska/console/sample/MassTextAsync.java
+++ b/console-sample/src/main/java/com/jraska/console/sample/MassTextAsync.java
@@ -1,0 +1,16 @@
+package com.jraska.console.sample;
+
+import android.os.AsyncTask;
+
+import com.jraska.console.Console;
+
+class MassTextAsync extends AsyncTask<Long, Void, Void> {
+  @Override
+  protected Void doInBackground(Long... params) {
+    long length = params[0];
+    for (int i = 0; i < length; i++) {
+      Console.writeLine("Line: "+i);
+    }
+    return null;
+  }
+}

--- a/console-sample/src/main/res/menu/menu_main.xml
+++ b/console-sample/src/main/res/menu/menu_main.xml
@@ -7,6 +7,10 @@
         android:title="@string/action_console_async"
         app:showAsAction="always" />
     <item
+        android:id="@+id/action_console_mass_text"
+        android:title="@string/action_console_mass_text"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/action_console_clear"
         android:title="@string/action_console_clear"
         android:icon="@drawable/ic_clear_24dp"

--- a/console-sample/src/main/res/values/strings.xml
+++ b/console-sample/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Console Sample</string>
     <string name="action_console_clear">Clear Console</string>
     <string name="action_console_async">Async</string>
+    <string name="action_console_mass_text">Mass Text</string>
 </resources>

--- a/console/src/main/java/com/jraska/console/Console.java
+++ b/console/src/main/java/com/jraska/console/Console.java
@@ -41,6 +41,14 @@ public class Console extends FrameLayout {
     write(END_LINE);
   }
 
+  public static void shouldBufferLogs(boolean enabled) {
+    buffer.shouldBufferLogs(enabled);
+  }
+
+  public static void setBufferDuration(long bufferDuration) {
+    buffer.setBufferDuration(bufferDuration);
+  }
+
   /**
    * Write provided object String representation to console and starts new line
    * "null" is written if the object is null
@@ -108,7 +116,7 @@ public class Console extends FrameLayout {
   private static volatile Handler uiThreadHandler;
   private static final Object lock = new Object();
 
-  private TextView text;
+  TextView text;
   private ScrollView scrollView;
 
   // This will serve as flag for all view modifying methods
@@ -186,7 +194,7 @@ public class Console extends FrameLayout {
     return userTouchingListener.isUserTouching() || flingProperty.isFlinging();
   }
 
-  private static Handler getUIThreadHandler() {
+  protected static Handler getUIThreadHandler() {
     synchronized (lock) {
       if (uiThreadHandler == null) {
         uiThreadHandler = new Handler(Looper.getMainLooper());

--- a/console/src/main/java/com/jraska/console/ConsoleBuffer.java
+++ b/console/src/main/java/com/jraska/console/ConsoleBuffer.java
@@ -100,9 +100,10 @@ class ConsoleBuffer {
           @Override
           public void run() {
             synchronized(lock) {
-              if (weakTextview.get() != null) {
+              TextView currentTextview = weakTextview.get();
+              if (currentTextview != null) {
                 // Text view still exists.
-                weakTextview.get().setText(buffer);
+                currentTextview.setText(buffer);
                 runnable = null;
                 waiting = false;
               }

--- a/console/src/main/java/com/jraska/console/ConsoleBuffer.java
+++ b/console/src/main/java/com/jraska/console/ConsoleBuffer.java
@@ -3,7 +3,9 @@ package com.jraska.console;
 import android.text.SpannableStringBuilder;
 import android.widget.TextView;
 
-final class ConsoleBuffer {
+import java.lang.ref.WeakReference;
+
+class ConsoleBuffer {
   //region Constants
 
   static int MAX_BUFFER_SIZE = 16_000;
@@ -16,6 +18,11 @@ final class ConsoleBuffer {
 
   private final SpannableStringBuilder buffer = new SpannableStringBuilder();
   private int maxBufferSize = MAX_BUFFER_SIZE;
+
+  private long interval = 1000; // one second.
+  private long lastCall = -1;
+  private boolean waiting = false, bufferText = false;
+  private Runnable runnable;
 
   //endregion
 
@@ -38,6 +45,17 @@ final class ConsoleBuffer {
 
   //region Methods
 
+  void shouldBufferLogs(boolean enabled) {
+    bufferText = enabled;
+  }
+
+  void setBufferDuration(long bufferDuration) {
+    if(interval <= 0) {
+      throw new IllegalArgumentException("Duration must be a positive number");
+    }
+    interval = bufferDuration;
+  }
+
   ConsoleBuffer append(Object o) {
     return append(o == null ? "null" : o.toString());
   }
@@ -51,16 +69,59 @@ final class ConsoleBuffer {
   }
 
   ConsoleBuffer clear() {
-    buffer.clear();
+    synchronized (lock) {
+      buffer.clear();
+    }
     return this;
   }
 
   ConsoleBuffer printTo(TextView textView) {
-    synchronized (lock) {
-      textView.setText(buffer);
+    if(bufferText) {
+      bufferedLogging(textView);
+    } else {
+      // Use the default synchronized implementation.
+      synchronized(lock) {
+        textView.setText(buffer);
+      }
     }
 
     return this;
+  }
+
+  private void bufferedLogging(final TextView textView) {
+    // delay the logging
+    long current = System.currentTimeMillis();
+    if(lastCall != -1 && ((current - lastCall) <= interval)) {
+      if(!waiting) {
+        // run this after n seconds.
+        waiting = true;
+        final WeakReference<TextView> weakTextview = new WeakReference<>(textView);
+        runnable = new Runnable() {
+          @Override
+          public void run() {
+            synchronized(lock) {
+              if (weakTextview.get() != null) {
+                // Text view still exists.
+                weakTextview.get().setText(buffer);
+                runnable = null;
+                waiting = false;
+              }
+            }
+
+          }
+        };
+        Console.getUIThreadHandler().postDelayed(runnable, interval);
+      }
+    } else {
+      // Cancel any existing setText runnables if any.
+      if(runnable != null) {
+        Console.getUIThreadHandler().removeCallbacks(runnable);
+      }
+      synchronized (lock) {
+        textView.setText(buffer);
+      }
+    }
+    lastCall = current;
   }
 
   private void ensureSize() {

--- a/console/src/test/java/com/jraska/console/ConsoleBufferTest.java
+++ b/console/src/test/java/com/jraska/console/ConsoleBufferTest.java
@@ -1,8 +1,11 @@
 package com.jraska.console;
 
 import android.widget.TextView;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
@@ -11,19 +14,30 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)
 public class ConsoleBufferTest {
   static final int ATTEMPTS_COUNT = 1000;
+  private ConsoleBuffer buffer;
+  private TextView testTextView;
+
+  @Before
+  public void setUp() {
+    buffer = new ConsoleBuffer();
+    buffer.setSize(10);
+    testTextView = new TextView(RuntimeEnvironment.application);
+    buffer = spy(buffer);
+    testTextView = spy(testTextView);
+  }
 
   @Test
   public void failsOnWrongBufferConcurrency() throws Exception {
-    final ConsoleBuffer buffer = new ConsoleBuffer();
-    buffer.setSize(10);
-
-    TextView testTextView = new TextView(RuntimeEnvironment.application);
-
     CountDownLatch finishLatch = new CountDownLatch(1);
     AppendRunnable appendRunnable = new AppendRunnable(buffer, finishLatch);
     new Thread(appendRunnable).start();
@@ -34,6 +48,68 @@ public class ConsoleBufferTest {
 
     boolean await = finishLatch.await(1, TimeUnit.SECONDS);
     assertThat(await).isTrue();
+  }
+
+  /**
+   * Assert that our logs are only called twice within a 3 second window.
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void assertSetTextCalledOncePerSecond() throws InterruptedException {
+    buffer.shouldBufferLogs(true);
+    assertSetTextCalledAtMost(3, TimeUnit.SECONDS.toMillis(3));
+    /*reset(testTextView);
+    assertSetTextCalledAtMost(5, TimeUnit.SECONDS.toMillis(5));
+    reset(testTextView);
+    assertSetTextCalledAtMost(2, TimeUnit.SECONDS.toMillis(2));*/
+  }
+
+  @Test
+  public void assertSetTextCalledOncePerHalfSecond() throws InterruptedException {
+    buffer.shouldBufferLogs(true);
+    buffer.setBufferDuration(500);
+    assertSetTextCalledAtMost(6, TimeUnit.SECONDS.toMillis(3));
+  }
+
+  /**
+   * Test that setText is called immediately even if buffering is enabled.
+   * @throws InterruptedException
+   */
+  @Test
+  public void assertSetTextCalledImmediately() throws InterruptedException {
+    buffer.shouldBufferLogs(true);
+    assertSetTextCalledAtMost(1, 0);
+  }
+
+  /**
+   * Test that the setText method is called multiple times per second if buffering is not set.
+   *
+   * @throws InterruptedException
+   */
+  @Test
+  public void assertSetTextCalledMultipleTimes() throws InterruptedException {
+    buffer.shouldBufferLogs(false);
+    assertSetTextCalledAtLeast(50, TimeUnit.SECONDS.toMillis(3));
+  }
+
+  private void assertSetTextCalledAtLeast(int numberOfTimes, long durationInMilliseconds) throws InterruptedException {
+    assertSetTextCalled(numberOfTimes, durationInMilliseconds, true);
+  }
+
+  private void assertSetTextCalledAtMost(int numberOfTimes, long durationInMilliseconds) throws InterruptedException {
+    assertSetTextCalled(numberOfTimes, durationInMilliseconds, false);
+  }
+
+  private void assertSetTextCalled(int numberOfTimes, long durationInMilliseconds, boolean atLeast) throws InterruptedException {
+    ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
+    doNothing().when(testTextView).setText(stringArgumentCaptor.capture());
+    CountDownLatch finishLatch = new CountDownLatch(1);
+    PrintRunnable printRunnable = new PrintRunnable(buffer, finishLatch, testTextView, durationInMilliseconds);
+    new Thread(printRunnable).start();
+    finishLatch.await();
+    verify(testTextView, atLeast ? atLeast(numberOfTimes) : atMost(numberOfTimes))
+            .setText(stringArgumentCaptor.getValue());
   }
 
   static class AppendRunnable implements Runnable {
@@ -49,6 +125,36 @@ public class ConsoleBufferTest {
       for (int i = 0; i < ATTEMPTS_COUNT; i++) {
         buffer.append("textToAppend");
         latch.countDown();
+      }
+    }
+  }
+
+  static class PrintRunnable implements Runnable {
+    private final ConsoleBuffer buffer;
+    private final CountDownLatch latch;
+    private final long durationInMilliseconds;
+    private final TextView testTextView;
+
+    PrintRunnable(ConsoleBuffer buffer, CountDownLatch latch, TextView testTextView, long durationInMilliseconds) {
+      this.buffer = buffer;
+      this.latch = latch;
+      this.testTextView = testTextView;
+      this.durationInMilliseconds = durationInMilliseconds;
+    }
+
+    @Override
+    public void run() {
+      long start = System.currentTimeMillis();
+      while (true) {
+        long current = System.currentTimeMillis();
+        long diff = current - (start + durationInMilliseconds);
+        buffer.append("x");
+        buffer.printTo(testTextView);
+
+        if (diff >= 0) {
+          latch.countDown();
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
Add buffer behaviour for situations where there are more logs than the UI can handle.

Related to issue #9.

The buffer behaviour can be enabled by calling `Console.shouldBufferLogs(true)`.
The default synchronized `setText()` implementation is used otherwise.