### PR TITLE
Improve performance in cases console is written from another thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ android:
 
     - extra-android-m2repository
     - extra-google-m2repository
+script:
+  - ./gradlew build check
 
 notifications:
   email: false

--- a/console-sample/build.gradle
+++ b/console-sample/build.gradle
@@ -12,6 +12,8 @@ android {
     targetSdkVersion rootProject.ext.targetSdkVersion
     versionName version
     versionCode rootProject.ext.versionCode
+
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   buildTypes {
@@ -32,6 +34,11 @@ android {
   lintOptions {
     abortOnError true
   }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 dependencies {
@@ -42,6 +49,10 @@ dependencies {
 
   implementation 'androidx.appcompat:appcompat:1.0.0'
   implementation 'com.google.android.material:material:1.0.0'
+
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta02'
+  androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
+  androidTestImplementation 'androidx.test:rules:1.1.0-beta02'
 }
 repositories {
   mavenCentral()

--- a/console-sample/src/androidTest/java/com/jraska/console/ConsolePerformanceTest.kt
+++ b/console-sample/src/androidTest/java/com/jraska/console/ConsolePerformanceTest.kt
@@ -10,7 +10,7 @@ class ConsolePerformanceTest {
   var testRule = ActivityTestRule<ConsoleActivity>(ConsoleActivity::class.java)
 
   @Test(timeout = 500) // generous to update Console few times, however it fails when scheduling is improper
-  fun givenTestHighLoad() {
+  fun testHighLoad() {
     for (x in 1..1000) {
       Console.writeLine("sampleText")
     }

--- a/console-sample/src/androidTest/java/com/jraska/console/ConsolePerformanceTest.kt
+++ b/console-sample/src/androidTest/java/com/jraska/console/ConsolePerformanceTest.kt
@@ -1,0 +1,18 @@
+package com.jraska.console
+
+import androidx.test.rule.ActivityTestRule
+import com.jraska.console.sample.ConsoleActivity
+import org.junit.Rule
+import org.junit.Test
+
+class ConsolePerformanceTest {
+  @get:Rule
+  var testRule = ActivityTestRule<ConsoleActivity>(ConsoleActivity::class.java)
+
+  @Test(timeout = 500) // generous to update Console few times, however it fails when scheduling is improper
+  fun givenTestHighLoad() {
+    for (x in 1..1000) {
+      Console.writeLine("sampleText")
+    }
+  }
+}


### PR DESCRIPTION
We scheduled a handler runnable each time anything was written into console, which led to poor performance when writing many entires from other threads.

Since handler message remains int main looper handler until next frame, we don't need to send any other message at this period and we can only check if handler has the message or not.